### PR TITLE
Add `hidePanel` configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built by [Yoshietru Nagata](https://github.com/nagata-yoshiteru) 🇯🇵 , [Ben
 - `ppm-pgm-viewer-for-vscode.imagepreview.defaultPreviewScale` : Default zoom level for image preview (default is 1.0)
 - `ppm-pgm-viewer-for-vscode.imagepreview.autoScalingMode` : Whether to use Auto Scaling Mode (default is false)
 - `ppm-pgm-viewer-for-vscode.imagepreview.uiPosition` : Panel UI position. (default is `left`)
+- `ppm-pgm-viewer-for-vscode.imagepreview.hidePanel` : Hide the panel. (default is `false`)
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,12 @@
 						"Show UI panel in the left side of the preview area",
 						"Show UI panel in the right side of the preview area"
 					]
+				},
+				"ppm-pgm-viewer-for-vscode.imagepreview.hidePanel": {
+					"type": "boolean",
+					"scope": "window",
+					"default": false,
+					"description": "Hide the panel."
 				}
 			}
 		}

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -16,6 +16,7 @@ const generateHTMLCanvas = (
   const defaultScale = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('defaultPreviewScale'));
   const autoScalingMode = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('autoScalingMode'));
   const uiPosition = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('uiPosition'));
+  const hidePanel = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('hidePanel'));
   const styles = {
     canvas: `padding: 0;
             margin: auto;
@@ -25,7 +26,8 @@ const generateHTMLCanvas = (
           padding: 0px 15px;
           margin: 15px 15px;
           width: 100px;
-          ${uiPosition}: 20px;`,
+          ${uiPosition}: 20px;
+          ${hidePanel ? "display: none" : ""}`,
     sizingButton: `width: 48%;
                   background-color: ${validateColor(btnColor) ? btnColor : "#dd4535"};
                   display: inline-block;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -107,6 +107,7 @@ const generateHTMLCanvas = (
           function zoom(e) {
             e.preventDefault();
             if(!e.ctrlKey) return;
+            if(${hidePanel}) return;
             if(e.deltaY < 0) {
               scale = scale * 2;
             } else {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -16,7 +16,7 @@ const generateHTMLCanvas = (
   const defaultScale = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('defaultPreviewScale'));
   const autoScalingMode = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('autoScalingMode'));
   const uiPosition = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('uiPosition'));
-  const hidePanel = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('hidePanel'));
+  const hidePanel = Boolean(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('hidePanel'));
   const styles = {
     canvas: `padding: 0;
             margin: auto;


### PR DESCRIPTION
This PR adds the `hidePanel` configuration flag that... well, hides the zoom/side panel entirely.
I have little use for the panel and it occupies a lot of the screen, it would be nice to have an option to disable it.

This is not the cleanest code, but I think it gets the job done.