### PR TITLE
Fix issues with file watcher not working on Windows

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -106,7 +106,8 @@ export default class ImagePreviewProvider
     this._createWebView(document, webviewPanel);
 
     const watcherAction = async (e: vscode.Uri) => {
-      if (document.uri.path === e.path) {
+      const docUriPath = document.uri.path.replace(/(\/[A-Z]:\/)/, (match) => match.toLowerCase());
+      if (docUriPath === e.path) {
         // filter an event
         const newDocument = await ImagePreviewDocument.create(
           vscode.Uri.parse(e.path)

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -118,11 +118,11 @@ export default class ImagePreviewProvider
     const relativePath = vscode.workspace.asRelativePath(document.uri);
     const fileName = path.parse(relativePath).base;
     const dirName = path.parse(relativePath).dir;
-    const benUri = vscode.Uri.file(dirName);
+    const fileUri = vscode.Uri.file(dirName);
 
     // This watcher is for files outside the workspace
     let globalWatcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(benUri, fileName)
+      new vscode.RelativePattern(fileUri, fileName)
     ); // possible to match another image
     const globalChangeFileSubscription =
       globalWatcher.onDidChange(watcherAction);

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -116,27 +116,20 @@ export default class ImagePreviewProvider
       }
     };
 
-    const relativePath = vscode.workspace.asRelativePath(document.uri);
-    const fileName = path.parse(relativePath).base;
-    const dirName = path.parse(relativePath).dir;
+    const absolutePath = document.uri.path;
+    const fileName = path.parse(absolutePath).base;
+    const dirName = path.parse(absolutePath).dir;
     const fileUri = vscode.Uri.file(dirName);
 
-    // This watcher is for files outside the workspace
-    let globalWatcher = vscode.workspace.createFileSystemWatcher(
+    // This watcher is for files both inside and outside the workspace
+    const globalWatcher = vscode.workspace.createFileSystemWatcher(
       new vscode.RelativePattern(fileUri, fileName)
     ); // possible to match another image
     const globalChangeFileSubscription =
       globalWatcher.onDidChange(watcherAction);
 
-    // This watcher is for the files in the workspace
-    let localWatcher = vscode.workspace.createFileSystemWatcher(
-      "**/" + relativePath
-    );
-    const localChangeFileSubscription = localWatcher.onDidChange(watcherAction);
-
     webviewPanel.onDidDispose(() => {
       globalChangeFileSubscription.dispose();
-      localChangeFileSubscription.dispose();
     });
   }
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -105,8 +105,9 @@ export default class ImagePreviewProvider
     };
     this._createWebView(document, webviewPanel);
 
-    const watcherAction = async (e) => {
-      if (document.uri.path === e.path) {  // filter an event
+    const watcherAction = async (e: vscode.Uri) => {
+      if (document.uri.path === e.path) {
+        // filter an event
         const newDocument = await ImagePreviewDocument.create(
           vscode.Uri.parse(e.path)
         );
@@ -120,13 +121,17 @@ export default class ImagePreviewProvider
     const benUri = vscode.Uri.file(dirName);
 
     // This watcher is for files outside the workspace
-    let globalWatcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(benUri, fileName));  // possible to match another image
-    const globalChangeFileSubscription = globalWatcher.onDidChange(watcherAction);
+    let globalWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(benUri, fileName)
+    ); // possible to match another image
+    const globalChangeFileSubscription =
+      globalWatcher.onDidChange(watcherAction);
 
     // This watcher is for the files in the workspace
-    let localWatcher = vscode.workspace.createFileSystemWatcher("**/" + relativePath);
+    let localWatcher = vscode.workspace.createFileSystemWatcher(
+      "**/" + relativePath
+    );
     const localChangeFileSubscription = localWatcher.onDidChange(watcherAction);
-
 
     webviewPanel.onDidDispose(() => {
       globalChangeFileSubscription.dispose();

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -27,7 +27,13 @@ const generateHTMLCanvas = (
           margin: 15px 15px;
           width: 100px;
           ${uiPosition}: 20px;
-          ${hidePanel ? "display: none" : ""}`,
+          ${hidePanel ? "display: none" : ""}
+          -webkit-touch-callout: none;
+          -webkit-user-select: none;
+          -khtml-user-select: none;
+          -moz-user-select: none;
+          -ms-user-select: none;
+          user-select: none;`,
     sizingButton: `width: 48%;
                   background-color: ${validateColor(btnColor) ? btnColor : "#dd4535"};
                   display: inline-block;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -29,11 +29,7 @@ const generateHTMLCanvas = (
           ${uiPosition}: 20px;
           ${hidePanel ? "display: none" : ""}
           -webkit-touch-callout: none;
-          -webkit-user-select: none;
-          -khtml-user-select: none;
-          -moz-user-select: none;
-          -ms-user-select: none;
-          user-select: none;`,
+          -webkit-user-select: none;`,
     sizingButton: `width: 48%;
                   background-color: ${validateColor(btnColor) ? btnColor : "#dd4535"};
                   display: inline-block;


### PR DESCRIPTION
The file watcher didn't seem to work for some file locations on Windows. This was mentioned in #33 and hopefully these changes should fix this issue. I noticed that for files outside of the workspace, the changes weren't being registered

I've tested this on MacOS and Windows and it seems to be working now.

I've also added a small style change so that we can no longer highlight the text in the sizing panel