### PR TITLE
Add missing semicolon to make the "Hide Panel" option work

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -27,7 +27,7 @@ const generateHTMLCanvas = (
           margin: 15px 15px;
           width: 100px;
           ${uiPosition}: 20px;
-          ${hidePanel ? "display: none" : ""}
+          ${hidePanel ? "display: none;" : ""}
           -webkit-touch-callout: none;
           -webkit-user-select: none;`,
     sizingButton: `width: 48%;


### PR DESCRIPTION
Hi! I noticed that the "Hide Panel" setting wasn't working properly due to a missing semicolon in the "display: none" property.
Thank you for creating this extension!