### PR TITLE
Fix issue with drag being active when mouse goes off screen

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -195,6 +195,7 @@ const generateHTMLCanvas = (
           canvasContainer.onmousedown = onMouseDown;
           canvasContainer.onmousemove = onMouseMove;
           canvasContainer.onmouseup = onMouseUp;
+          canvasContainer.onmouseout = onMouseUp;
 
           window.addEventListener('message', event => {
             message = event.data;


### PR DESCRIPTION
**Change Type:** Bug Fix

**Description:** Fixes issue where the drag state is maintained while the mouse goes off the canvas. Once the mouse re-enters the canvas zone, the drag state is still active, leading to unnatural behaviour for user.

**Before:**

https://github.com/user-attachments/assets/63b9707d-00b4-4d6f-8e0b-c8f383a624df

**After:**

https://github.com/user-attachments/assets/40030b95-972e-4251-8ad9-71cd927f3e65

Note for @nagata-yoshiteru: I have another PR as well, so I think we should do one release once thats in as well
