### PR TITLE
Add pixel hover information

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -63,13 +63,13 @@ const generateHTMLCanvas = (
           <p id="height-display">Height: ${height}px</p>
           <p id="scale-display">Zoom: 100%</p>
           <div style="margin-bottom: 15px">
-            <p style="${styles.labelGroup}>Mouse Pixel:</p>
-            <p style="${styles.labelGroup} id="pixel-loc-x">X: 0</p>
-            <p style="${styles.labelGroup} id="pixel-loc-y">Y: 0</p>
+            <p style="${styles.labelGroup}">Mouse Pixel:</p>
+            <p style="${styles.labelGroup}" id="pixel-loc-x">X: 0</p>
+            <p style="${styles.labelGroup}" id="pixel-loc-y">Y: 0</p>
             <hr style="${styles.separator}">
-            <p style="${styles.labelGroup} id="pixel-color-r">R: 0 (0.0)</p>
-            <p style="${styles.labelGroup} id="pixel-color-g">G: 0 (0.0)</p>
-            <p style="${styles.labelGroup} id="pixel-color-b">B: 0 (0.0)</p>
+            <p style="${styles.labelGroup}" id="pixel-color-r">R: 0 (0.0)</p>
+            <p style="${styles.labelGroup}" id="pixel-color-g">G: 0 (0.0)</p>
+            <p style="${styles.labelGroup}" id="pixel-color-b">B: 0 (0.0)</p>
           </div>
           <div style="margin-bottom: 5px">
             <div onclick="scale = scale * 2; showImg(scale);" style="${styles.sizingButton}">+</div>

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -46,7 +46,13 @@ const generateHTMLCanvas = (
                 background-color: white;
                 margin: 0.5rem 0;`,
     labelGroup: `padding: 0;
-                 margin: 0;`
+                 margin: 0;`,
+    colorBox: `position: absolute;
+               right: 0;
+               top: 2px;
+               width: 12px;
+               height: 12px;
+               border: 1px solid white;`,
   };
 
   return `
@@ -58,18 +64,22 @@ const generateHTMLCanvas = (
       </head>
       <body>
         <div style="${styles.info}">
-          <p id="type-display">Type: ${imgType}</p>
-          <p id="width-display">Width: ${width}px</p>
-          <p id="height-display">Height: ${height}px</p>
-          <p id="scale-display">Zoom: 100%</p>
-          <div style="margin-bottom: 15px">
-            <p style="${styles.labelGroup}">Mouse Pixel:</p>
+          <div style="margin: 15px 0">
+            <p style="${styles.labelGroup} font-weight: bolder">Image Info</p>
+            <p style="${styles.labelGroup}" id="type-display">Type: ${imgType}</p>
+            <p style="${styles.labelGroup}" id="width-display">Width: ${width}px</p>
+            <p style="${styles.labelGroup}" id="height-display">Height: ${height}px</p>
+            <p style="${styles.labelGroup}" id="scale-display">Zoom: 100%</p>
+          </div>
+          <hr style="${styles.separator}">
+          <div style="margin-bottom: 15px; position: relative">
+            <p style="${styles.labelGroup} font-weight: bolder">Mouse Pixel</p>
             <p style="${styles.labelGroup}" id="pixel-loc-x">X: 0</p>
             <p style="${styles.labelGroup}" id="pixel-loc-y">Y: 0</p>
-            <hr style="${styles.separator}">
             <p style="${styles.labelGroup}" id="pixel-color-r">R: 0 (0.0)</p>
             <p style="${styles.labelGroup}" id="pixel-color-g">G: 0 (0.0)</p>
             <p style="${styles.labelGroup}" id="pixel-color-b">B: 0 (0.0)</p>
+            <div style="${styles.colorBox}" id="pixel-color-box"></div>
           </div>
           <div style="margin-bottom: 5px">
             <div onclick="scale = scale * 2; showImg(scale);" style="${styles.sizingButton}">+</div>
@@ -97,6 +107,7 @@ const generateHTMLCanvas = (
           const pixelColorRDisplay = document.getElementById('pixel-color-r');
           const pixelColorGDisplay = document.getElementById('pixel-color-g');
           const pixelColorBDisplay = document.getElementById('pixel-color-b');
+          const pixelColorBox = document.getElementById('pixel-color-box');
 
           if(${autoScalingMode}){
             const html = document.getElementsByTagName("html")[0];
@@ -233,6 +244,8 @@ const generateHTMLCanvas = (
 
             const colBF32 = (col.data[2] / 255.0).toFixed(4);
             pixelColorBDisplay.innerHTML = "B: " + String(colBF32) + " (" + String(col.data[2]) + ")";
+
+            pixelColorBox.style.backgroundColor = "rgb(" + String(col.data[0]) + ", " + String(col.data[1]) + ", " + String(col.data[2]) + ")";
           };
 
           function onMouseUp(e) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -41,6 +41,10 @@ const generateHTMLCanvas = (
                   margin-bottom: 15px;
                   cursor: pointer;
                   user-select: none;`,
+    separator: `border: 0;
+                height: 1px;
+                background-color: white;
+                margin: 0.5rem 0;`
   };
 
   return `
@@ -56,6 +60,15 @@ const generateHTMLCanvas = (
           <p id="width-display">Width: ${width}px</p>
           <p id="height-display">Height: ${height}px</p>
           <p id="scale-display">Zoom: 100%</p>
+          <div style="margin-bottom: 15px">
+            <p style="margin: 0; padding: 0">Mouse Pixel:</p>
+            <p style="margin: 0; padding: 0" id="pixel-loc-x">X: 0</p>
+            <p style="margin: 0; padding: 0" id="pixel-loc-y">Y: 0</p>
+            <hr style="${styles.separator}">
+            <p style="margin: 0; padding: 0" id="pixel-color-r">R: 0 (0.0)</p>
+            <p style="margin: 0; padding: 0" id="pixel-color-g">G: 0 (0.0)</p>
+            <p style="margin: 0; padding: 0" id="pixel-color-b">B: 0 (0.0)</p>
+          </div>
           <div style="margin-bottom: 5px">
             <div onclick="scale = scale * 2; showImg(scale);" style="${styles.sizingButton}">+</div>
             <div onclick="scale = scale / 2; showImg(scale);" style="${styles.sizingButton}">-</div>
@@ -76,6 +89,13 @@ const generateHTMLCanvas = (
           const widthDisplay = document.getElementById('width-display');
           const heightDisplay = document.getElementById('height-display');
           const scaleDisplay = document.getElementById('scale-display');
+
+          const pixelLocXDisplay = document.getElementById('pixel-loc-x');
+          const pixelLocYDisplay = document.getElementById('pixel-loc-y');
+          const pixelColorRDisplay = document.getElementById('pixel-color-r');
+          const pixelColorGDisplay = document.getElementById('pixel-color-g');
+          const pixelColorBDisplay = document.getElementById('pixel-color-b');
+
           if(${autoScalingMode}){
             const html = document.getElementsByTagName("html")[0];
             const alpha = 0.05;
@@ -160,6 +180,11 @@ const generateHTMLCanvas = (
             });
           }
 
+          function clamp(val, min, max)
+          {
+            return Math.min(Math.max(val, min), max);
+          }
+
           const lastPos = { x: 0, y: 0 };
           let isDragging = false;
           const canvasContainer = document.getElementById('canvas-container');
@@ -185,6 +210,27 @@ const generateHTMLCanvas = (
               lastPos.x = e.clientX;
               lastPos.y = e.clientY;
             }
+
+            const boundingRect = canvas.getBoundingClientRect();
+            const canvasSpaceX = clamp(e.clientX - boundingRect.left, 0, boundingRect.width - 1);
+            const canvasSpaceY = clamp(e.clientY - boundingRect.top, 0, boundingRect.height - 1);
+
+            const imageSpaceX = Math.floor(canvasSpaceX / scale);
+            const imageSpaceY = Math.floor(canvasSpaceY / scale);
+            pixelLocXDisplay.innerHTML = "X: " + String(imageSpaceX);
+            pixelLocYDisplay.innerHTML = "Y: " + String(imageSpaceY);
+
+            const ctx = canvas.getContext('2d');
+            const col = ctx.getImageData(canvasSpaceX, canvasSpaceY, boundingRect.width, boundingRect.height);
+
+            const colRF32 = (col.data[0] / 255.0).toFixed(4);
+            pixelColorRDisplay.innerHTML = "R: " + String(colRF32) + " (" + String(col.data[0]) + ")";
+
+            const colGF32 = (col.data[1] / 255.0).toFixed(4);
+            pixelColorGDisplay.innerHTML = "G: " + String(colGF32) + " (" + String(col.data[1]) + ")";
+
+            const colBF32 = (col.data[2] / 255.0).toFixed(4);
+            pixelColorBDisplay.innerHTML = "B: " + String(colBF32) + " (" + String(col.data[2]) + ")";
           };
 
           function onMouseUp(e) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -44,7 +44,9 @@ const generateHTMLCanvas = (
     separator: `border: 0;
                 height: 1px;
                 background-color: white;
-                margin: 0.5rem 0;`
+                margin: 0.5rem 0;`,
+    labelGroup: `padding: 0;
+                 margin: 0;`
   };
 
   return `
@@ -61,13 +63,13 @@ const generateHTMLCanvas = (
           <p id="height-display">Height: ${height}px</p>
           <p id="scale-display">Zoom: 100%</p>
           <div style="margin-bottom: 15px">
-            <p style="margin: 0; padding: 0">Mouse Pixel:</p>
-            <p style="margin: 0; padding: 0" id="pixel-loc-x">X: 0</p>
-            <p style="margin: 0; padding: 0" id="pixel-loc-y">Y: 0</p>
+            <p style="${styles.labelGroup}>Mouse Pixel:</p>
+            <p style="${styles.labelGroup} id="pixel-loc-x">X: 0</p>
+            <p style="${styles.labelGroup} id="pixel-loc-y">Y: 0</p>
             <hr style="${styles.separator}">
-            <p style="margin: 0; padding: 0" id="pixel-color-r">R: 0 (0.0)</p>
-            <p style="margin: 0; padding: 0" id="pixel-color-g">G: 0 (0.0)</p>
-            <p style="margin: 0; padding: 0" id="pixel-color-b">B: 0 (0.0)</p>
+            <p style="${styles.labelGroup} id="pixel-color-r">R: 0 (0.0)</p>
+            <p style="${styles.labelGroup} id="pixel-color-g">G: 0 (0.0)</p>
+            <p style="${styles.labelGroup} id="pixel-color-b">B: 0 (0.0)</p>
           </div>
           <div style="margin-bottom: 5px">
             <div onclick="scale = scale * 2; showImg(scale);" style="${styles.sizingButton}">+</div>


### PR DESCRIPTION
**Change Type:** New Feature

**Description:** This feature allows the user to inspect that pixel coordinates and colour information of the pixel they are hovering over. The feature is designed to be scale invariant.

**Note:** @nagata-yoshiteru What do you think about the layout of the new p tags? Should I remove the separator line? If you have any feedback on the UI layout for the new feature, I can change it. Thank you!

**Scale Invariance:**

https://github.com/user-attachments/assets/305454d8-f4a4-4443-9f5c-e1cb59edab0d

**Coordinate Accuracy:**

https://github.com/user-attachments/assets/fd2c0ee1-939a-4580-ba01-d849674774ff